### PR TITLE
fixed training/validation/test data split

### DIFF
--- a/trainoptim.lua
+++ b/trainoptim.lua
@@ -208,7 +208,10 @@ for epoch = 1, options.maxEpoch do
         i = i + 1
         --test set
         if i % testEvery==0 then
-            local meanerr=runValidationSet()
+            if loader.nval>0 then
+				local meanerr=runValidationSet()
+			end
+			
             if(options.track==1) then
                 pcall(ModelTracker.sendStatistic({["category"]="Next",["name"]="Loss",["group"]="test",["n"]=totalcount,["crossid"]=crossid,["value"]=meanerr}))
             end

--- a/util/WordSplitLMMinibatchLoader.lua
+++ b/util/WordSplitLMMinibatchLoader.lua
@@ -107,10 +107,20 @@ function WordSplitLMMinibatchLoader.create(data_dir, batch_size,seq_length, spli
 
     -- divide data to train/val and allocate rest to test
     self.ntrain = math.floor(self.train:size(1)/batch_size )-1
-    self.nval = math.floor(self.val:size(1)/batch_size)-1
-    self.ntest = math.floor(self.test:size(1)/batch_size)-1
+	
+	if self.val ~=nil then
+		self.nval = math.floor(self.val:size(1)/batch_size)-1		
+	else
+		self.nval=0
+	end	
+	if self.test ~=nil then		
+		self.ntest = math.floor(self.test:size(1)/batch_size)-1
+	else
+		self.ntest=0
+	end	
+	
     self.batch_size = batch_size
-    print ('Val Size: ' .. self.val:size(1))
+    print ('Val Size: ' .. self.nval)
 
     self.split_sizes = {self.ntrain, self.nval, self.ntest}
     self.batch_ix = {0,0,0 }
@@ -526,9 +536,13 @@ function WordSplitLMMinibatchLoader:text_to_tensor(in_textfile, out_vocabfile, o
 
     local data = {}
     data.train = examples:narrow(1,1,ntrain)
-    data.val = examples:narrow(1,ntrain+1,nval)
-    data.test = examples:narrow(1,ntrain+nval+1,ntest)
-
+	
+	if nval>0 then 
+		data.val = examples:narrow(1,ntrain+1,nval)		
+	end
+	if ntest>0 then
+		data.test = examples:narrow(1,ntrain+nval+1,ntest)
+	end
 
     -- save output preprocessed files
     print('saving ' .. out_vocabfile)


### PR DESCRIPTION
fixed errors from using zero validation and/or test data size in WordSplitLMMinibatchLoader.create(...)

Now either or both of validation and test data size can be set to zero. This fixes issue #3.
